### PR TITLE
[Review] Networking

### DIFF
--- a/PixabaySearch/Controllers/SearchResultsViewController.swift
+++ b/PixabaySearch/Controllers/SearchResultsViewController.swift
@@ -12,6 +12,10 @@ class SearchResultsViewController: UIViewController, UITableViewDelegate {
     var searchString = String()
     private let imagesTableView = UITableView()
     private var imageInfoArray: Array<ImageInfo>?
+
+    // TODO: add the property to store the instance of the networkService
+
+    // TODO: add the init here
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -72,6 +76,7 @@ class SearchResultsViewController: UIViewController, UITableViewDelegate {
         if CacheManager.shared.isImageInfoSaved(query: searchString) == true {
             imageInfoArray = CacheManager.shared.returnImageInfo(query: searchString)
         } else {
+            // TODO: replace the call of the shared instance
             NetworkService.shared.fetchImageData(query: query, amount: 25) { (result) in
                 switch result {
                 case let .failure(error):
@@ -90,6 +95,9 @@ class SearchResultsViewController: UIViewController, UITableViewDelegate {
     }
     
     private func reloadTableView() {
+        // [Riccardo] Directly accessing the `dispatchGroup` is not a good practice.
+        // The way in which the downloads are orchestrated is an implementation detail of the network service.
+        // could you think about a way to hide this from the VC.
         NetworkService.shared.dispatchGroup.notify(queue: .main) {
             self.imagesTableView.reloadData()
         }

--- a/PixabaySearch/Services/NetworkProvider.swift
+++ b/PixabaySearch/Services/NetworkProvider.swift
@@ -9,8 +9,10 @@ import Foundation
 import UIKit
 
 class NetworkService {
-    
+
+    // [Riccardo] We can remove the shared property, we are moving away from the singleton approach
     static let shared = NetworkService()
+    // this property should be private or fileprivate. It is a detail of how the download is handled.
     let dispatchGroup = DispatchGroup()
 
     private let apiKey = "13197033-03eec42c293d2323112b4cca6"
@@ -23,7 +25,18 @@ class NetworkService {
     
     //TODO: value must be between 3-200, limit it? | maybe more parameters later?
     func fetchImageData(query: String, amount: Int, completion: @escaping (Result<[ImageInfo], NetworkError>) -> Void ) {
-        
+
+      // [Riccardo] This function is doing a lot of things alltogether.
+      // It is managing the dispatch group.
+      // It is performing the network requests
+      // It is handling the result.
+      // I think we could achieve a better code readability if we split this function in other smaller ones.
+
+      // Furthermore, why do you need the dispatchGroup? DispatchGroups are usually needed when we have to perform multiple downloads and we want wait for all of them to finish.
+      // For example we have 10 image urls and we would like to download all of them before invoking the callback.
+      // In our case, we are performing 1 network requests. We can remove the dispatch group completely.
+
+
         dispatchGroup.enter()
 
         var  urlComps = baseUrlComponents
@@ -33,13 +46,17 @@ class NetworkService {
         ]
         
         guard let url = urlComps.url else {
+            // In this case, we already entered a process in the dispatch group (Line 29). However, we are never exiting it.
+            // This makes everything wait for something that will never occur.
             completion(.failure(.missingUrl))
             return
         }
         
         URLSession.shared.dataTask(with: url) { (data, response, error) in
             if let error = error {
+                // Same issue as above: you have to exit every time you are about to call the completion.
                 completion(.failure(.apiError(error)))
+                // In case of an error, can I reach this line? Shouldn't we return here?
             }
             
             guard
@@ -59,8 +76,12 @@ class NetworkService {
                 }
             }
             catch let unsuccessfulQuery {
+              // We can reach this point only in case we failed to decode the response.
+              // The error returned is not the right one because we are telling the user that the query is unsuccessful
+              // but it may not be the case. For example, the query could be the right one, but we may have hit a rate limit.
                 DispatchQueue.main.async {
                     completion(.failure(.other(unsuccessfulQuery)))
+                    // we still miss leaving the dispatch group
                 }
             }
         }.resume()


### PR DESCRIPTION
Hi Andras, how are you doing?

As promised here is the first review on the NetworkingLayer. Unfortunately, I had to fork your project because the invitation expired while I was on holiday. :( 

---
So, let's start by explaining why it is not a good idea to have a `Singleton` in our code.
There are at least 2 cases where having hardcoded access to the `Singleton` could create troubles.
- what if you want to test this method and the backend you are accessing is down? The `fetchImageData` will always fail, even for the tests in which you want to test what happens when everything should go well.
- what if you need to create another service to retrieve the data, with the very same interface, but that is not a singleton? You will have to update all the calling sites.

**How can we solve this?**
The idea is to use [Dependency Injection](https://en.wikipedia.org/wiki/Dependency_injection).
We want to inject an instance of the `NetworkService` into the `SearchResultViewController`.
There are 2 alternatives here:
- **initialization**.
- **method settings**.
The **initialization** alternative pushes us to create a custom initializer for our `SearchResultViewController` that takes a `NetworkService` parameter. When creating the VC, we have to pass an instance of the service.
The **method settings** asks us to declare a new optional `var` in the VC and it lets the creator of the VC set it later on.

Among the two, the better approach is the **initialization** method, of course.

So... The first step will be to refactor all the VC that uses the `NetworkService.shared` and:
- add a `let` property for the network service
- add an init which takes this new parameter
- replace the `NetworkService.shared` with the new property.

I added a few other comments to improve other aspects of the networking.

PS: usually, the default with iOS and Xcode is to use 2 spaces instead of 4 for tabulation. In Xcode, you can customize them by pressing `command+,`, select `Text Editing`, select `Indentation`, and set both `Tab Width` and `Indent Width` to 2.